### PR TITLE
update the fabricmod.json to allow 1.19.1/2

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -35,7 +35,7 @@
 
 	"depends": {
 		"cloth-config": "*",
-		"minecraft": "1.19+"
+		"minecraft": "1.19.*"
 	},
 
 	"custom": {


### PR DESCRIPTION
right now, when trying to launch with 1.19.1 or higher, it doesnt work. changing it from a + to a .* fixes that