### PR TITLE
Fixes compatibility with yacl 2.1.1

### DIFF
--- a/fabric/src/main/java/nl/enjarai/doabarrelroll/moonlightconfigs/yacl/YACLCompat.java
+++ b/fabric/src/main/java/nl/enjarai/doabarrelroll/moonlightconfigs/yacl/YACLCompat.java
@@ -2,7 +2,7 @@ package nl.enjarai.doabarrelroll.moonlightconfigs.yacl;
 
 import dev.isxander.yacl.api.*;
 import dev.isxander.yacl.gui.controllers.ColorController;
-import dev.isxander.yacl.gui.controllers.EnumController;
+import dev.isxander.yacl.gui.controllers.cycling.EnumController;
 import dev.isxander.yacl.gui.controllers.LabelController;
 import dev.isxander.yacl.gui.controllers.TickBoxController;
 import dev.isxander.yacl.gui.controllers.slider.DoubleSliderController;

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -13,7 +13,8 @@
 	],
 	"contact": {
 		"homepage": "https://enjarai.nl",
-		"sources": "https://github.com/enjarai/do-a-barrel-roll"
+		"sources": "https://github.com/enjarai/do-a-barrel-roll",
+		"issues": "https://github.com/enjarai/do-a-barrel-roll/issues"
 	},
 	
 	"license": "GPL-3.0",

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,20 +5,20 @@ minecraft_version = 1.19.3
 enabled_platforms = fabric
 
 mod_id = do-a-barrel-roll
-mod_version = 2.3.1
+mod_version = 2.3.2
 maven_group =  nl.enjarai
 
-yarn_version = 1.19.3+build.1
+yarn_version = 1.19.3+build.3
 
 fabric_loader_version=0.14.11
-fabric_api_version=0.68.1+1.19.3
+fabric_api_version=0.69.1+1.19.3
 
 forge_version=1.19.2-43.1.30
 
 cicada_version=0.1.0+a2
-modmenu_version = 5.0.0-alpha.4
+modmenu_version = 5.0.2
 cloth_config_version=8.0.75
-yacl_version=1.5.0
+yacl_version=2.1.1
 mixin_extras_version=0.1.0
 
 


### PR DESCRIPTION
- Updated yacl version to 2.1.1
- Added issues page link to fabric.mod.json

Other mods I am using require a newer version of yacl and it made dabr config screen inaccessible, this should fix that.
Also, could you add information about the config screen & how to access it to modrinth mod page? That would help new users of this mod a lot :)