### PR TITLE
Add Syntax Highlighting to Expression Fields

### DIFF
--- a/src/client/java/nl/enjarai/doabarrelroll/compat/yacl/ExpressionParserController.java
+++ b/src/client/java/nl/enjarai/doabarrelroll/compat/yacl/ExpressionParserController.java
@@ -6,6 +6,9 @@ import dev.isxander.yacl3.gui.AbstractWidget;
 import dev.isxander.yacl3.gui.YACLScreen;
 import dev.isxander.yacl3.gui.controllers.string.IStringController;
 import dev.isxander.yacl3.gui.controllers.string.StringControllerElement;
+import net.minecraft.text.MutableText;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
 import nl.enjarai.doabarrelroll.math.ExpressionParser;
 
 public record ExpressionParserController(Option<ExpressionParser> option) implements IStringController<ExpressionParser> {
@@ -18,7 +21,39 @@ public record ExpressionParserController(Option<ExpressionParser> option) implem
     public void setFromString(String value) {
         option.requestSet(new ExpressionParser(value));
     }
-
+    
+    @Override
+    public Text formatValue() {
+        var context = new SyntaxHighlightingContext(getString());
+        MutableText formattedText = Text.literal("");
+        
+        while (context.getCurrent() != (char)0) {
+            if (context.getCurrent() == '$') {
+                formattedText.append(formatChar(context.getCurrent(), SyntaxType.Variable));
+                context.position++;
+                
+                while (isLetter(context.getCurrent()) || context.getCurrent() == '_') {
+                    formattedText.append(formatChar(context.getCurrent(), SyntaxType.Variable));
+                    context.position++;
+                }
+            } else if (Character.isDigit(context.getCurrent()) || context.getCurrent() == '.') {
+                formattedText.append(formatChar(context.getCurrent(), SyntaxType.Number));
+                context.position++;
+            } else if (isOperator(context.getCurrent())) {
+                formattedText.append(formatChar(context.getCurrent(), SyntaxType.Operator));
+                context.position++;
+            } else if (Character.isWhitespace(context.getCurrent())) {
+                formattedText.append(String.valueOf(context.getCurrent()));
+                context.position++;
+            } else {
+                formattedText.append(formatChar(context.getCurrent(), SyntaxType.Error));
+                context.position++;
+            }
+        }
+        
+        return formattedText;
+    }
+    
     @Override
     public AbstractWidget provideWidget(YACLScreen screen, Dimension<Integer> widgetDimension) {
         return new StringControllerElement(this, screen, widgetDimension, true) {
@@ -28,4 +63,56 @@ public record ExpressionParserController(Option<ExpressionParser> option) implem
             }
         };
     }
+    
+    private boolean isLetter(char c) {
+        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+    }
+    
+    private boolean isOperator(char c) {
+        return c == '+' || c == '-' || c == '*' || c == '/' || c == '(' || c == ')';
+    }
+    
+    private MutableText formatChar(char ch, SyntaxType type) {
+        String str = String.valueOf(ch);
+        
+        switch (type) {
+            case Variable -> {
+                return Text.literal(str).formatted(Formatting.GREEN);
+            }
+            
+            case Operator -> {
+                return Text.literal(str).formatted(Formatting.LIGHT_PURPLE);
+            }
+            
+            case Error -> {
+                return Text.literal(str).formatted(Formatting.RED);
+            }
+            
+            case Number -> {
+                return Text.literal(str).formatted(Formatting.AQUA);
+            }
+        }
+        
+        return null;
+    }
+}
+
+class SyntaxHighlightingContext {
+    public int position = 0;
+    public String rawText;
+    
+    public SyntaxHighlightingContext(String raw) {
+        this.rawText = raw;
+    }
+    
+    char getCurrent() {
+        if (position >= rawText.length()) return (char)0;
+        return rawText.charAt(position);
+    }
+}
+
+enum SyntaxType {
+    Variable,
+    Operator,
+    Error, Number
 }

--- a/src/client/java/nl/enjarai/doabarrelroll/compat/yacl/ExpressionParserController.java
+++ b/src/client/java/nl/enjarai/doabarrelroll/compat/yacl/ExpressionParserController.java
@@ -6,10 +6,9 @@ import dev.isxander.yacl3.gui.AbstractWidget;
 import dev.isxander.yacl3.gui.YACLScreen;
 import dev.isxander.yacl3.gui.controllers.string.IStringController;
 import dev.isxander.yacl3.gui.controllers.string.StringControllerElement;
-import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
 import nl.enjarai.doabarrelroll.math.ExpressionParser;
+import nl.enjarai.doabarrelroll.math.SyntaxHighlighter;
 
 public record ExpressionParserController(Option<ExpressionParser> option) implements IStringController<ExpressionParser> {
     @Override
@@ -24,34 +23,7 @@ public record ExpressionParserController(Option<ExpressionParser> option) implem
     
     @Override
     public Text formatValue() {
-        var context = new SyntaxHighlightingContext(getString());
-        MutableText formattedText = Text.literal("");
-        
-        while (context.getCurrent() != (char)0) {
-            if (context.getCurrent() == '$') {
-                formattedText.append(formatChar(context.getCurrent(), SyntaxType.Variable));
-                context.position++;
-                
-                while (isLetter(context.getCurrent()) || context.getCurrent() == '_') {
-                    formattedText.append(formatChar(context.getCurrent(), SyntaxType.Variable));
-                    context.position++;
-                }
-            } else if (Character.isDigit(context.getCurrent()) || context.getCurrent() == '.') {
-                formattedText.append(formatChar(context.getCurrent(), SyntaxType.Number));
-                context.position++;
-            } else if (isOperator(context.getCurrent())) {
-                formattedText.append(formatChar(context.getCurrent(), SyntaxType.Operator));
-                context.position++;
-            } else if (Character.isWhitespace(context.getCurrent())) {
-                formattedText.append(String.valueOf(context.getCurrent()));
-                context.position++;
-            } else {
-                formattedText.append(formatChar(context.getCurrent(), SyntaxType.Error));
-                context.position++;
-            }
-        }
-        
-        return formattedText;
+        return SyntaxHighlighter.highlightText(getString());
     }
     
     @Override
@@ -63,56 +35,4 @@ public record ExpressionParserController(Option<ExpressionParser> option) implem
             }
         };
     }
-    
-    private boolean isLetter(char c) {
-        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
-    }
-    
-    private boolean isOperator(char c) {
-        return c == '+' || c == '-' || c == '*' || c == '/' || c == '(' || c == ')';
-    }
-    
-    private MutableText formatChar(char ch, SyntaxType type) {
-        String str = String.valueOf(ch);
-        
-        switch (type) {
-            case Variable -> {
-                return Text.literal(str).formatted(Formatting.GREEN);
-            }
-            
-            case Operator -> {
-                return Text.literal(str).formatted(Formatting.LIGHT_PURPLE);
-            }
-            
-            case Error -> {
-                return Text.literal(str).formatted(Formatting.RED);
-            }
-            
-            case Number -> {
-                return Text.literal(str).formatted(Formatting.AQUA);
-            }
-        }
-        
-        return null;
-    }
-}
-
-class SyntaxHighlightingContext {
-    public int position = 0;
-    public String rawText;
-    
-    public SyntaxHighlightingContext(String raw) {
-        this.rawText = raw;
-    }
-    
-    char getCurrent() {
-        if (position >= rawText.length()) return (char)0;
-        return rawText.charAt(position);
-    }
-}
-
-enum SyntaxType {
-    Variable,
-    Operator,
-    Error, Number
 }

--- a/src/client/java/nl/enjarai/doabarrelroll/math/SyntaxHighlighter.java
+++ b/src/client/java/nl/enjarai/doabarrelroll/math/SyntaxHighlighter.java
@@ -49,7 +49,7 @@ public class SyntaxHighlighter {
 		
 		switch (type) {
 			case Variable -> {
-				return Text.literal(str).formatted(Formatting.GREEN);
+				return Text.literal(str).formatted(Formatting.ITALIC);
 			}
 			
 			case Operator -> {

--- a/src/client/java/nl/enjarai/doabarrelroll/math/SyntaxHighlighter.java
+++ b/src/client/java/nl/enjarai/doabarrelroll/math/SyntaxHighlighter.java
@@ -1,6 +1,7 @@
 package nl.enjarai.doabarrelroll.math;
 
 import net.minecraft.text.MutableText;
+import net.minecraft.text.Style;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import nl.enjarai.doabarrelroll.DoABarrelRoll;
@@ -12,7 +13,7 @@ public class SyntaxHighlighter {
 		MutableText formattedText = Text.literal("");
 		SyntaxHighlightContext context = new SyntaxHighlightContext(text);
 		
-		DoABarrelRoll.LOGGER.info("Begun syntax highlighting");
+		if (debugLog) DoABarrelRoll.LOGGER.info("Begun syntax highlighting");
 		
 		while (context.getCurrent() != (char)0) {
 			if (context.getCurrent() == '$') { //variables
@@ -43,13 +44,13 @@ public class SyntaxHighlighter {
 				formattedText.append(formatText(context.getCurrent(), SyntaxType.Number));
 				context.position++;
 				if (debugLog) DoABarrelRoll.LOGGER.info("Coloring number");
-			} else if (isLetter(context.getCurrent())) { //functions
+			} else if (isLetter(context.getCurrent())) { //functions and constants
 				StringBuilder builder = new StringBuilder();
 				
-				while (isLetter(context.getCurrent())) {
+				while (isLetter(context.getCurrent()) || context.getCurrent() == '_') {
 					builder.append(context.getCurrent());
 					context.position++;
-					if (debugLog) DoABarrelRoll.LOGGER.info("Reading possible function");
+					if (debugLog) DoABarrelRoll.LOGGER.info("Reading possible function or constant");
 				}
 				
 				String builtResult = builder.toString();
@@ -89,7 +90,7 @@ public class SyntaxHighlighter {
 	
 	public static boolean isConstant(String str) {
 		switch (str) {
-			case "pi" -> {
+			case "PI", "E", "TO_RAD", "TO_DEG" -> {
 				return true;
 			}
 		}
@@ -152,7 +153,7 @@ public class SyntaxHighlighter {
 			}
 			
 			case Constant -> {
-				return Text.literal(str).formatted(Formatting.ITALIC);
+				return Text.literal(str).setStyle(Style.EMPTY.withColor(0xFFA500));
 			}
 			
 			case Scope -> {

--- a/src/client/java/nl/enjarai/doabarrelroll/math/SyntaxHighlighter.java
+++ b/src/client/java/nl/enjarai/doabarrelroll/math/SyntaxHighlighter.java
@@ -27,11 +27,11 @@ public class SyntaxHighlighter {
 					if (debugLog) DoABarrelRoll.LOGGER.info("Coloring variable");
 				}
 			} else if (context.getCurrent() == '-' || context.getCurrent() == '+') { //unary operators
-				if (Character.isDigit(context.peek()) && context.lastIsOperator()) {
+				if (Character.isDigit(context.peek()) && context.lastIsNotValue()) {
 					formattedText.append(formatText(context.getCurrent(), SyntaxType.Number));
 					context.position++;
 					if (debugLog) DoABarrelRoll.LOGGER.info("Coloring number");
-				} else if (isLetter(context.peek()) && context.lastIsOperator()) {
+				} else if (isLetter(context.peek()) && context.lastIsNotValue()) {
 					formattedText.append(formatText(context.getCurrent(), SyntaxType.Function));
 					context.position++;
 					if (debugLog) DoABarrelRoll.LOGGER.info("Coloring function");
@@ -191,13 +191,14 @@ class SyntaxHighlightContext {
 		return rawText.charAt(i);
 	}
 	
-	public boolean lastIsOperator() {
+	public boolean lastIsNotValue() {
 		int tempPos = position;
 		
 		while (tempPos > 0) {
 			tempPos--;
 			
-			if (SyntaxHighlighter.isOperator(getByIndex(tempPos))) {
+			if (SyntaxHighlighter.isOperator(getByIndex(tempPos))
+					|| SyntaxHighlighter.isScope(getByIndex(tempPos))) {
 				return true;
 			} else if (!Character.isWhitespace(getByIndex(tempPos))) {
 				break;

--- a/src/client/java/nl/enjarai/doabarrelroll/math/SyntaxHighlighter.java
+++ b/src/client/java/nl/enjarai/doabarrelroll/math/SyntaxHighlighter.java
@@ -5,30 +5,56 @@ import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 
 public class SyntaxHighlighter {
-	public static MutableText highlightText(String str) {
+	public static Text highlightText(String text) {
 		MutableText formattedText = Text.literal("");
-		SyntaxHighlightContext context = new SyntaxHighlightContext(str);
+		SyntaxHighlightContext context = new SyntaxHighlightContext(text);
 		
 		while (context.getCurrent() != (char)0) {
-			if (context.getCurrent() == '$') {
-				formattedText.append(formatChar(context.getCurrent(), SyntaxType.Variable));
+			if (context.getCurrent() == '$') { //variables
+				formattedText.append(String.valueOf(context.getCurrent()));
 				context.position++;
 				
 				while (isLetter(context.getCurrent()) || context.getCurrent() == '_') {
-					formattedText.append(formatChar(context.getCurrent(), SyntaxType.Variable));
+					formattedText.append(formatText(context.getCurrent(), SyntaxType.Variable));
 					context.position++;
 				}
-			} else if (Character.isDigit(context.getCurrent()) || context.getCurrent() == '.') {
-				formattedText.append(formatChar(context.getCurrent(), SyntaxType.Number));
+//			} else if (context.getCurrent() == '-' || context.getCurrent() == '+') { //unary operators
+//				if (Character.isDigit(context.peek())) {
+//					formattedText.append(formatText(context.getCurrent(), SyntaxType.Number));
+//					context.position++;
+//				} else if (isLetter(context.peek())) {
+//					formattedText.append(formatText(context.getCurrent(), SyntaxType.Function));
+//					context.position++;
+//				}
+			} else if (Character.isDigit(context.getCurrent()) || context.getCurrent() == '.') { //numbers
+				formattedText.append(formatText(context.getCurrent(), SyntaxType.Number));
 				context.position++;
-			} else if (isOperator(context.getCurrent())) {
-				formattedText.append(formatChar(context.getCurrent(), SyntaxType.Operator));
+//			} else if (isLetter(context.getCurrent())) { //functions
+//				StringBuilder builder = new StringBuilder();
+//
+//				while (isLetter(context.getCurrent())) {
+//					builder.append(context.getCurrent());
+//					context.position++;
+//				}
+//
+//				String builtResult = builder.toString();
+//
+//				if (isKeyword(builtResult) && context.getCurrent() == '(') {
+//					formattedText.append(formatText(builtResult, SyntaxType.Function));
+//				} else {
+//					formattedText.append(formatText(builtResult, SyntaxType.Error));
+//				}
+			} else if (isOperator(context.getCurrent())) { //typical operators
+				formattedText.append(formatText(context.getCurrent(), SyntaxType.Operator));
 				context.position++;
-			} else if (Character.isWhitespace(context.getCurrent())) {
+			} else if (isScope(context.getCurrent())) { //parentheses
+				formattedText.append(formatText(context.getCurrent(), SyntaxType.Scope));
+				context.position++;
+			} else if (Character.isWhitespace(context.getCurrent())) { //whitespace
 				formattedText.append(String.valueOf(context.getCurrent()));
 				context.position++;
-			} else {
-				formattedText.append(formatChar(context.getCurrent(), SyntaxType.Error));
+			} else { //errors
+				formattedText.append(formatText(context.getCurrent(), SyntaxType.Error));
 				context.position++;
 			}
 		}
@@ -36,20 +62,42 @@ public class SyntaxHighlighter {
 		return formattedText;
 	}
 	
+	public static boolean isKeyword(String str) {
+		switch (str) {
+			case "sqrt", "sin", "cos",
+					"tan", "asin", "acos",
+					"atan", "abs", "exp",
+					"ceil", "floor", "log",
+					"round", "randint", "min",
+					"max" -> {
+				return true;
+			}
+		}
+		
+		return false;
+	}
+	
 	public static boolean isLetter(char c) {
 		return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
 	}
 	
 	public static boolean isOperator(char c) {
-		return c == '+' || c == '-' || c == '*' || c == '/' || c == '(' || c == ')';
+		return c == '+' || c == '-' || c == '*' || c == '/' || c == '^';
 	}
 	
-	public static MutableText formatChar(char ch, SyntaxType type) {
+	public static boolean isScope(char c) {
+		 return c == ',' || c == '(' || c == ')';
+	}
+	
+	public static MutableText formatText(char ch, SyntaxType type) {
 		String str = String.valueOf(ch);
-		
+		return formatText(str, type);
+	}
+	
+	public static MutableText formatText(String str, SyntaxType type) {
 		switch (type) {
 			case Variable -> {
-				return Text.literal(str).formatted(Formatting.ITALIC);
+				return Text.literal(str).formatted(Formatting.GREEN);
 			}
 			
 			case Operator -> {
@@ -62,6 +110,14 @@ public class SyntaxHighlighter {
 			
 			case Number -> {
 				return Text.literal(str).formatted(Formatting.AQUA);
+			}
+			
+			case Function -> {
+				return Text.literal(str).formatted(Formatting.BLUE);
+			}
+			
+			case Scope -> {
+				return Text.literal(str);
 			}
 		}
 		
@@ -77,9 +133,22 @@ class SyntaxHighlightContext {
 		this.rawText = raw;
 	}
 	
+	public String peek(int amount) {
+		if (position + amount >= rawText.length()) return null;
+		return rawText.substring(position, position + amount);
+	}
+	
+	public char peek() {
+		return getByIndex(position + 1);
+	}
+	
 	public char getCurrent() {
-		if (position >= rawText.length()) return (char)0;
-		return rawText.charAt(position);
+		return getByIndex(position);
+	}
+	
+	public char getByIndex(int i) {
+		if (i >= rawText.length()) return (char)0;
+		return rawText.charAt(1);
 	}
 }
 
@@ -87,5 +156,7 @@ enum SyntaxType {
 	Variable,
 	Operator,
 	Error,
+	Scope,
+	Function,
 	Number
 }

--- a/src/client/java/nl/enjarai/doabarrelroll/math/SyntaxHighlighter.java
+++ b/src/client/java/nl/enjarai/doabarrelroll/math/SyntaxHighlighter.java
@@ -1,0 +1,91 @@
+package nl.enjarai.doabarrelroll.math;
+
+import net.minecraft.text.MutableText;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+
+public class SyntaxHighlighter {
+	public static MutableText highlightText(String str) {
+		MutableText formattedText = Text.literal("");
+		SyntaxHighlightContext context = new SyntaxHighlightContext(str);
+		
+		while (context.getCurrent() != (char)0) {
+			if (context.getCurrent() == '$') {
+				formattedText.append(formatChar(context.getCurrent(), SyntaxType.Variable));
+				context.position++;
+				
+				while (isLetter(context.getCurrent()) || context.getCurrent() == '_') {
+					formattedText.append(formatChar(context.getCurrent(), SyntaxType.Variable));
+					context.position++;
+				}
+			} else if (Character.isDigit(context.getCurrent()) || context.getCurrent() == '.') {
+				formattedText.append(formatChar(context.getCurrent(), SyntaxType.Number));
+				context.position++;
+			} else if (isOperator(context.getCurrent())) {
+				formattedText.append(formatChar(context.getCurrent(), SyntaxType.Operator));
+				context.position++;
+			} else if (Character.isWhitespace(context.getCurrent())) {
+				formattedText.append(String.valueOf(context.getCurrent()));
+				context.position++;
+			} else {
+				formattedText.append(formatChar(context.getCurrent(), SyntaxType.Error));
+				context.position++;
+			}
+		}
+		
+		return formattedText;
+	}
+	
+	public static boolean isLetter(char c) {
+		return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+	}
+	
+	public static boolean isOperator(char c) {
+		return c == '+' || c == '-' || c == '*' || c == '/' || c == '(' || c == ')';
+	}
+	
+	public static MutableText formatChar(char ch, SyntaxType type) {
+		String str = String.valueOf(ch);
+		
+		switch (type) {
+			case Variable -> {
+				return Text.literal(str).formatted(Formatting.GREEN);
+			}
+			
+			case Operator -> {
+				return Text.literal(str).formatted(Formatting.LIGHT_PURPLE);
+			}
+			
+			case Error -> {
+				return Text.literal(str).formatted(Formatting.RED);
+			}
+			
+			case Number -> {
+				return Text.literal(str).formatted(Formatting.AQUA);
+			}
+		}
+		
+		return null;
+	}
+}
+
+class SyntaxHighlightContext {
+	public int position = 0;
+	public String rawText;
+	
+	public SyntaxHighlightContext(String raw) {
+		this.rawText = raw;
+	}
+	
+	public char getCurrent() {
+		if (position >= rawText.length()) return (char)0;
+		return rawText.charAt(position);
+	}
+}
+
+enum SyntaxType {
+	Variable,
+	Operator,
+	Error,
+	Number
+}

--- a/src/client/java/nl/enjarai/doabarrelroll/math/SyntaxHighlighter.java
+++ b/src/client/java/nl/enjarai/doabarrelroll/math/SyntaxHighlighter.java
@@ -18,32 +18,32 @@ public class SyntaxHighlighter {
 					formattedText.append(formatText(context.getCurrent(), SyntaxType.Variable));
 					context.position++;
 				}
-//			} else if (context.getCurrent() == '-' || context.getCurrent() == '+') { //unary operators
-//				if (Character.isDigit(context.peek())) {
-//					formattedText.append(formatText(context.getCurrent(), SyntaxType.Number));
-//					context.position++;
-//				} else if (isLetter(context.peek())) {
-//					formattedText.append(formatText(context.getCurrent(), SyntaxType.Function));
-//					context.position++;
-//				}
+			} else if (context.getCurrent() == '-' || context.getCurrent() == '+') { //unary operators
+				if (Character.isDigit(context.peek())) {
+					formattedText.append(formatText(context.getCurrent(), SyntaxType.Number));
+					context.position++;
+				} else if (isLetter(context.peek())) {
+					formattedText.append(formatText(context.getCurrent(), SyntaxType.Function));
+					context.position++;
+				}
 			} else if (Character.isDigit(context.getCurrent()) || context.getCurrent() == '.') { //numbers
 				formattedText.append(formatText(context.getCurrent(), SyntaxType.Number));
 				context.position++;
-//			} else if (isLetter(context.getCurrent())) { //functions
-//				StringBuilder builder = new StringBuilder();
-//
-//				while (isLetter(context.getCurrent())) {
-//					builder.append(context.getCurrent());
-//					context.position++;
-//				}
-//
-//				String builtResult = builder.toString();
-//
-//				if (isKeyword(builtResult) && context.getCurrent() == '(') {
-//					formattedText.append(formatText(builtResult, SyntaxType.Function));
-//				} else {
-//					formattedText.append(formatText(builtResult, SyntaxType.Error));
-//				}
+			} else if (isLetter(context.getCurrent())) { //functions
+				StringBuilder builder = new StringBuilder();
+
+				while (isLetter(context.getCurrent())) {
+					builder.append(context.getCurrent());
+					context.position++;
+				}
+
+				String builtResult = builder.toString();
+
+				if (isKeyword(builtResult) && context.getCurrent() == '(') {
+					formattedText.append(formatText(builtResult, SyntaxType.Function));
+				} else {
+					formattedText.append(formatText(builtResult, SyntaxType.Error));
+				}
 			} else if (isOperator(context.getCurrent())) { //typical operators
 				formattedText.append(formatText(context.getCurrent(), SyntaxType.Operator));
 				context.position++;


### PR DESCRIPTION
Adds a class to generate colored `Text` from a string, for the purpose of syntax highlighting in the YACL config screen. While the colours are hardcoded, they should be fairly easy to change if need be. Here's an example screenshot. 
![image](https://github.com/enjarai/do-a-barrel-roll/assets/131844170/ad35067f-4144-4a06-8a0c-e828f048667d)
