### PR TITLE
Fix thrust particles not appearing when mods are changing the thrust output via event

### DIFF
--- a/common/src/main/java/nl/enjarai/doabarrelroll/DoABarrelRollClient.java
+++ b/common/src/main/java/nl/enjarai/doabarrelroll/DoABarrelRollClient.java
@@ -18,14 +18,12 @@ public class DoABarrelRollClient {
     public static final Smoother YAW_SMOOTHER = new Smoother();
     public static final Smoother ROLL_SMOOTHER = new Smoother();
     public static final RollGroup FALL_FLYING_GROUP = RollGroup.of(DoABarrelRoll.id("fall_flying"));
-    public static double throttle = 0;
 
     public static void init() {
         FALL_FLYING_GROUP.trueIf(DoABarrelRollClient::isFallFlying);
 
         // Keyboard modifiers
         RollEvents.EARLY_CAMERA_MODIFIERS.register(context -> context
-                .useModifier(RotationModifiers::manageThrottle, ModConfig.INSTANCE::getEnableThrust)
                 .useModifier(RotationModifiers.buttonControls(1800)),
                 2000, FALL_FLYING_GROUP);
 
@@ -57,7 +55,6 @@ public class DoABarrelRollClient {
         PITCH_SMOOTHER.clear();
         YAW_SMOOTHER.clear();
         ROLL_SMOOTHER.clear();
-        throttle = 0;
     }
 
     public static boolean isFallFlying() {

--- a/common/src/main/java/nl/enjarai/doabarrelroll/flight/RotationModifiers.java
+++ b/common/src/main/java/nl/enjarai/doabarrelroll/flight/RotationModifiers.java
@@ -1,10 +1,10 @@
 package nl.enjarai.doabarrelroll.flight;
 
+import java.util.HashMap;
+import java.util.Map;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Smoother;
 import nl.enjarai.doabarrelroll.DoABarrelRoll;
-import nl.enjarai.doabarrelroll.DoABarrelRollClient;
 import nl.enjarai.doabarrelroll.ModKeybindings;
 import nl.enjarai.doabarrelroll.api.event.RollContext;
 import nl.enjarai.doabarrelroll.api.rotation.RotationInstant;
@@ -12,18 +12,15 @@ import nl.enjarai.doabarrelroll.config.ModConfig;
 import nl.enjarai.doabarrelroll.config.Sensitivity;
 import nl.enjarai.doabarrelroll.math.MagicNumbers;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public class RotationModifiers {
     public static final double ROLL_REORIENT_CUTOFF = Math.sqrt(10.0 / 3.0);
 
     public static RollContext.ConfiguresRotation buttonControls(double power) {
         return (rotationInstant, context) -> {
             var delta = power * context.getRenderDelta();
-            var pitch = 0;
-            var yaw = 0;
-            var roll = 0;
+            var pitch = 0.0;
+            var yaw = 0.0;
+            var roll = 0.0;
 
             if (ModKeybindings.PITCH_UP.isPressed()) {
                 pitch -= delta;

--- a/common/src/main/java/nl/enjarai/doabarrelroll/flight/RotationModifiers.java
+++ b/common/src/main/java/nl/enjarai/doabarrelroll/flight/RotationModifiers.java
@@ -93,15 +93,15 @@ public class RotationModifiers {
         return (rotationInstant, context) -> {
             if (Double.isNaN(rotationInstant.pitch())) {
                 rotationInstant = RotationInstant.of(0, rotationInstant.yaw(), rotationInstant.roll());
-                DoABarrelRoll.LOGGER.warn("NaN found in pitch for " + name + ", setting to 0 as fallback");
+                DoABarrelRoll.LOGGER.warn("NaN found in pitch for {}, setting to 0 as fallback", name);
             }
             if (Double.isNaN(rotationInstant.yaw())) {
                 rotationInstant = RotationInstant.of(rotationInstant.pitch(), 0, rotationInstant.roll());
-                DoABarrelRoll.LOGGER.warn("NaN found in yaw for " + name + ", setting to 0 as fallback");
+                DoABarrelRoll.LOGGER.warn("NaN found in yaw for {}, setting to 0 as fallback", name);
             }
             if (Double.isNaN(rotationInstant.roll())) {
                 rotationInstant = RotationInstant.of(rotationInstant.pitch(), rotationInstant.yaw(), 0);
-                DoABarrelRoll.LOGGER.warn("NaN found in roll for " + name + ", setting to 0 as fallback");
+                DoABarrelRoll.LOGGER.warn("NaN found in roll for {}, setting to 0 as fallback", name);
             }
             return rotationInstant;
         };

--- a/common/src/main/java/nl/enjarai/doabarrelroll/flight/RotationModifiers.java
+++ b/common/src/main/java/nl/enjarai/doabarrelroll/flight/RotationModifiers.java
@@ -92,22 +92,6 @@ public class RotationModifiers {
         return rotationInstant.add(0, 0, -rollDelta * strength * delta);
     }
 
-    public static RotationInstant manageThrottle(RotationInstant rotationInstant, RollContext context) {
-        var delta = context.getRenderDelta();
-
-        if (ModKeybindings.THRUST_FORWARD.isPressed()) {
-            DoABarrelRollClient.throttle += 0.1 * delta;
-        } else if (ModKeybindings.THRUST_BACKWARD.isPressed()) {
-            DoABarrelRollClient.throttle -= 0.1 * delta;
-        } else {
-            DoABarrelRollClient.throttle -= DoABarrelRollClient.throttle * 0.95 * delta;
-        }
-
-        DoABarrelRollClient.throttle = MathHelper.clamp(DoABarrelRollClient.throttle, 0, ModConfig.INSTANCE.getMaxThrust());
-
-        return rotationInstant;
-    }
-
     public static RollContext.ConfiguresRotation fixNaN(String name) {
         return (rotationInstant, context) -> {
             if (Double.isNaN(rotationInstant.pitch())) {

--- a/common/src/main/java/nl/enjarai/doabarrelroll/mixin/client/LivingEntityMixin.java
+++ b/common/src/main/java/nl/enjarai/doabarrelroll/mixin/client/LivingEntityMixin.java
@@ -8,7 +8,6 @@ import net.minecraft.particle.ParticleTypes;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
-import nl.enjarai.doabarrelroll.DoABarrelRollClient;
 import nl.enjarai.doabarrelroll.ModKeybindings;
 import nl.enjarai.doabarrelroll.api.event.ThrustEvents;
 import nl.enjarai.doabarrelroll.config.ModConfig;
@@ -35,14 +34,17 @@ public abstract class LivingEntityMixin extends Entity {
             )
     )
     private Vec3d doABarrelRoll$wrapElytraVelocity(Vec3d original) {
-        if (!(((LivingEntity) (Object) this) instanceof ClientPlayerEntity) || !ModConfig.INSTANCE.getEnableThrust()) return original;
+        if (!((Object) this instanceof ClientPlayerEntity) || !ModConfig.INSTANCE.getEnableThrust()) return original;
 
         Vec3d rotation = getRotationVector();
         Vec3d velocity = getVelocity();
 
+        double throttleSign = ModKeybindings.THRUST_FORWARD.isPressed() ? 1 : ModKeybindings.THRUST_BACKWARD.isPressed() ? -1 : 0;
+        throttleSign = ThrustEvents.modifyThrustInput(throttleSign);
+
         if (ModConfig.INSTANCE.getThrustParticles()) {
-            int particleDensity = (int) MathHelper.clamp(DoABarrelRollClient.throttle * 10, 0, 10);
-            if (DoABarrelRollClient.throttle > 0.1 && getWorld().getTime() % (11 - particleDensity) == 0) {
+            int particleDensity = (int) MathHelper.clamp(throttleSign * 10, 0, 10);
+            if (throttleSign > 0.1 && getWorld().getTime() % (11 - particleDensity) == 0) {
                 var pPos = getPos().add(velocity.multiply(0.5).negate());
                 getWorld().addParticle(
                         ParticleTypes.CAMPFIRE_SIGNAL_SMOKE,
@@ -52,8 +54,6 @@ public abstract class LivingEntityMixin extends Entity {
             }
         }
 
-        double throttleSign = ModKeybindings.THRUST_FORWARD.isPressed() ? 1 : ModKeybindings.THRUST_BACKWARD.isPressed() ? -1 : 0;
-        throttleSign = ThrustEvents.modifyThrustInput(throttleSign);
         double maxSpeed = ModConfig.INSTANCE.getMaxThrust();
         double speedIncrease = Math.max(maxSpeed - velocity.length(), 0) / maxSpeed * throttleSign;
         double acceleration = ModConfig.INSTANCE.getThrustAcceleration() * speedIncrease;

--- a/common/src/main/java/nl/enjarai/doabarrelroll/mixin/client/roll/CameraMixin.java
+++ b/common/src/main/java/nl/enjarai/doabarrelroll/mixin/client/roll/CameraMixin.java
@@ -115,7 +115,8 @@ public abstract class CameraMixin implements RollCamera {
             method = "setRotation",
             at = @At(
                     value = "INVOKE",
-                    target = "Lorg/joml/Quaternionf;rotationYXZ(FFF)Lorg/joml/Quaternionf;"
+                    target = "Lorg/joml/Quaternionf;rotationYXZ(FFF)Lorg/joml/Quaternionf;",
+                    remap = false
             ),
             index = 2
     )

--- a/fabric/src/main/java/nl/enjarai/doabarrelroll/compat/controlify/ControlifyCompat.java
+++ b/fabric/src/main/java/nl/enjarai/doabarrelroll/compat/controlify/ControlifyCompat.java
@@ -67,15 +67,6 @@ public class ControlifyCompat implements ControlifyEntrypoint {
         return forward - backward;
     }
 
-    public static RotationInstant manageThrottle(RotationInstant rotationInstant, RollContext context) {
-        var delta = context.getRenderDelta();
-
-        DoABarrelRollClient.throttle += getThrustModifier() * delta;
-        DoABarrelRollClient.throttle = MathHelper.clamp(DoABarrelRollClient.throttle, 0, ModConfig.INSTANCE.getMaxThrust());
-
-        return rotationInstant;
-    }
-
     @Override
     public void onControlifyPreInit(ControlifyApi controlifyApi) {
         var bindings = ControlifyBindApi.get();
@@ -138,9 +129,6 @@ public class ControlifyCompat implements ControlifyEntrypoint {
                 .addKeyCorrelation(ModKeybindings.THRUST_BACKWARD)
         );
 
-        RollEvents.EARLY_CAMERA_MODIFIERS.register(context -> context
-                .useModifier(ControlifyCompat::manageThrottle, ModConfig.INSTANCE::getEnableThrust),
-                8, DoABarrelRollClient::isFallFlying);
         RollEvents.LATE_CAMERA_MODIFIERS.register(context -> context
                 .useModifier(this::applyToRotation),
                 5, DoABarrelRollClient::isFallFlying);

--- a/fabric/src/main/java/nl/enjarai/doabarrelroll/compat/controlify/ControlifyCompat.java
+++ b/fabric/src/main/java/nl/enjarai/doabarrelroll/compat/controlify/ControlifyCompat.java
@@ -7,7 +7,6 @@ import dev.isxander.controlify.api.entrypoint.ControlifyEntrypoint;
 import dev.isxander.controlify.api.event.ControlifyEvents;
 import dev.isxander.controlify.bindings.BindContext;
 import net.minecraft.text.Text;
-import net.minecraft.util.math.MathHelper;
 import nl.enjarai.doabarrelroll.DoABarrelRoll;
 import nl.enjarai.doabarrelroll.DoABarrelRollClient;
 import nl.enjarai.doabarrelroll.ModKeybindings;


### PR DESCRIPTION
Some additional fixes:
- Added missing `remap=false` in CameraMixin to silence a warning
- Fixed an error that would cause unintentional rounding to int when processing keybindings for flight controls
- Replaced string concatenation with string template in a few logger calls