### PR TITLE
[Neoforge] Improve compatibility with third person mods

### DIFF
--- a/src/main/java/nl/enjarai/doabarrelroll/mixin/client/roll/CameraMixin.java
+++ b/src/main/java/nl/enjarai/doabarrelroll/mixin/client/roll/CameraMixin.java
@@ -168,6 +168,18 @@ public abstract class CameraMixin implements RollCamera {
             return original - MathHelper.lerp(tickDelta.get(), lastRollBack, rollBack);
         }
     }
+
+    @ModifyArg(
+            method = "setRotation(FF)V",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/client/render/Camera;setRotation(FFF)V"
+            ),
+            index = 2
+    )
+    private float doABarrelRoll$retainRoll(float original) {
+        return this.roll;
+    }
     *///?}
 
 


### PR DESCRIPTION
This PR tries to improve the compatibility with other third person mods for neoforge. The problem is that other mods, such as Shoulder Surfing Reloaded, could use the `setRotation(FF)V` method of the `Camera` class, which resets the camera roll to 0°. This PR changes the behavior of the method, such that the camera roll is not reset. There may be better ways of doing it 🤷. Related to #203, https://github.com/Exopandora/ShoulderSurfing/issues/285.