### PR TITLE
Adds onControllifyInit to ControllifyCompat

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ deps.mixin_squared=0.1.2-beta.4
 deps.mixin_extras=0.4.1
 deps.cond_mixin=0.6.2
 deps.perm_api=0.4.0
-deps.fabric_loader=0.16.10
+deps.fabric_loader=0.17.2
 
 # Versioned Dependencies
 deps.minecraft=[VERSIONED]

--- a/src/main/java/nl/enjarai/doabarrelroll/compat/controlify/ControlifyCompat.java
+++ b/src/main/java/nl/enjarai/doabarrelroll/compat/controlify/ControlifyCompat.java
@@ -5,6 +5,8 @@ import dev.isxander.controlify.api.ControlifyApi;
 import dev.isxander.controlify.api.bind.ControlifyBindApi;
 import dev.isxander.controlify.api.bind.InputBindingSupplier;
 import dev.isxander.controlify.api.entrypoint.ControlifyEntrypoint;
+import dev.isxander.controlify.api.entrypoint.InitContext;
+import dev.isxander.controlify.api.entrypoint.PreInitContext;
 import dev.isxander.controlify.api.event.ControlifyEvents;
 import dev.isxander.controlify.bindings.BindContext;
 import net.minecraft.text.Text;
@@ -68,7 +70,11 @@ public class ControlifyCompat implements ControlifyEntrypoint {
     }
 
     @Override
-    public void onControlifyPreInit(ControlifyApi controlifyApi) {
+    public void onControlifyInit(InitContext initContext) {
+    }
+
+    @Override
+    public void onControlifyPreInit(PreInitContext preInitContext) {
         var bindings = ControlifyBindApi.get();
         bindings.registerBindContext(FALL_FLYING);
 
@@ -130,7 +136,7 @@ public class ControlifyCompat implements ControlifyEntrypoint {
         );
 
         RollEvents.LATE_CAMERA_MODIFIERS.register(context -> context
-                .useModifier(this::applyToRotation),
+                        .useModifier(this::applyToRotation),
                 5, DoABarrelRollClient::isFallFlying);
 
         ThrustEvents.MODIFY_THRUST_INPUT.register(input -> input + getThrustModifier());
@@ -140,6 +146,7 @@ public class ControlifyCompat implements ControlifyEntrypoint {
                 event.lookInput().zero();
             }
         });
+
     }
 
     @Override

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     kotlin("jvm") version "2.0.0" apply false
     kotlin("plugin.serialization") version "2.0.0" apply false
     id("co.uzzu.dotenv.gradle") version "4.0.0"
-    id("dev.architectury.loom") version "1.10-SNAPSHOT" apply false
+    id("dev.architectury.loom") version "1.11-SNAPSHOT" apply false
     id("me.modmuss50.mod-publish-plugin") version "0.5.+" apply false
 }
 stonecutter active "1.21.6-fabric" /* [SC] DO NOT EDIT */

--- a/versions/1.21.6-fabric/gradle.properties
+++ b/versions/1.21.6-fabric/gradle.properties
@@ -3,7 +3,7 @@ loom.platform=fabric
 # Global
 deps.yarn_build=1
 deps.compat=\
-    controlify=5q2runiM
+    controlify=fz8YVXuw
 deps.compat_runtime=
 
 # Fabric


### PR DESCRIPTION
Fixes #221 

Hope this is okay, the issue seemed trivial so I decided to spend 4 hours fixing it (:

The pr fixes the issue by updating the controlify dependency and updating the ControlifyCompat class to work with the changes.


Changed ControlifyCompat to work with new controlify changes
Bumps Controlify dependency to controlify 2.4.1
Bumps fabric_loader to 1.17.2 to support newer controlify
Bumps loom to support one of the above changes (idk it didn't build complaining some mod (probably controlify) wasn't upgraded and didn't seem to break anything) 