### PR TITLE
Fix typo in language files

### DIFF
--- a/src/main/resources/assets/do_a_barrel_roll/lang/en_us.yml
+++ b/src/main/resources/assets/do_a_barrel_roll/lang/en_us.yml
@@ -128,7 +128,7 @@ config.do_a_barrel_roll:
       This will kick any players that don't have the mod loaded.
     installed_timeout: Installed Check Timeout
     installed_timeout.description: >
-      The amount of time in seconds that the server will 
+      The amount of time in ticks that the server will 
       wait for a client to respond to the handshake before kicking them.
       §lIncrease this if players with bad connections are getting kicked even though they have the mod installed.
   gameplay:

--- a/src/main/resources/assets/do_a_barrel_roll/lang/es_mx.yml
+++ b/src/main/resources/assets/do_a_barrel_roll/lang/es_mx.yml
@@ -122,7 +122,7 @@ config.do_a_barrel_roll:
       Esto expulsará a cualquier jugador que no tenga el mod cargado.
     installed_timeout: Tiempo de espera de verificación de instalación
     installed_timeout.description: >
-      La cantidad de tiempo en segundos que el servidor esperará a que un cliente responda al saludo antes de expulsarlo.
+      La cantidad de tiempo en ticks que el servidor esperará a que un cliente responda al saludo antes de expulsarlo.
       §lAumenta esto si los jugadores con conexiones lentas están siendo expulsados a pesar de tener el mod instalado.
   gameplay:
     .: Jugabilidad


### PR DESCRIPTION
In here, the unit of the `installed_timeout ` option is "ticks" instead of the "seconds", so changed to be same as the description in README and the logic.

For reference, see https://github.com/enjarai/do-a-barrel-roll/blob/9ece7ae843e6c7c651c08a9592d23320629fa810/src/main/java/nl/enjarai/doabarrelroll/net/HandshakeServer.java#L70